### PR TITLE
schema/validation implementation in paddles

### DIFF
--- a/paddles/controllers/errors.py
+++ b/paddles/controllers/errors.py
@@ -1,7 +1,12 @@
-from pecan import expose, response
+from pecan import expose, response, request
 
 
 class ErrorsController(object):
+
+    @expose('json')
+    def schema(self, **kw):
+        response.status = 400
+        return dict(message=str(request.validation_error))
 
     @expose('json')
     def invalid(self, **kw):

--- a/paddles/schemas.py
+++ b/paddles/schemas.py
@@ -1,0 +1,5 @@
+from notario.validators import cherry_pick, types
+
+
+def run_schema():
+    return ('name', types.string)

--- a/paddles/schemas.py
+++ b/paddles/schemas.py
@@ -1,4 +1,4 @@
-from notario.validators import cherry_pick, types
+from notario.validators import types
 
 
 def run_schema():

--- a/paddles/tests/controllers/test_runs.py
+++ b/paddles/tests/controllers/test_runs.py
@@ -17,7 +17,20 @@ class TestRunController(TestApp):
 
     def test_post_invalid(self):
         response = self.app.post_json('/runs/', dict(), expect_errors=True)
+        error_message = response.json['message']
+        assert error_message == '-> top level has no data to validate against schema'
+
         assert response.status_int == 400
+
+    def test_post_no_name(self):
+        response = self.app.post_json('/runs/', dict(bar=1), expect_errors=True)
+        error_message = response.json['message']
+        assert error_message == "-> bar key did not match 'name'"
+
+    def test_post_name_is_not_a_string(self):
+        response = self.app.post_json('/runs/', dict(name=1), expect_errors=True)
+        error_message = response.json['message']
+        assert error_message == "-> name -> 1 did not pass validation against callable: string (not of type string)"
 
     def test_get_invalid_url_on_run(self):
         response = self.app.get('/runs/suck/', expect_errors=True)
@@ -65,7 +78,7 @@ class TestRunController(TestApp):
         # this is just posting a dict in the body, no proper headers
         response = self.app.post('/runs/', dict(), expect_errors=True)
         assert response.status_int == 400
-        assert response.json['message'] == 'could not decode JSON body'
+        assert response.json['message'] == 'No JSON object could be decoded'
 
     def test_create_new_job(self):
         self.app.post_json('/runs/', dict(name="foo"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ tzlocal==1.1.1
 WebTest==2.0.15
 wsgiref==0.1.2
 gunicorn==19.1.1
+pecan-notario

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     author_email='',
     install_requires=[
         "pecan",
+        "pecan-notario",
     ],
     test_suite='paddles',
     zip_safe=False,


### PR DESCRIPTION
Introduces validation/schemas for a single controller method, demonstrating how to make use of the new API
for validating JSON that has been loaded into a Python dictionary.

Reference issue: http://tracker.ceph.com/issues/9017

Tests where modified only slightly to accommodate the new wording.
