### PR TITLE
Add percentage to queue_stats command

### DIFF
--- a/paddles/commands/queue_stats.py
+++ b/paddles/commands/queue_stats.py
@@ -39,12 +39,16 @@ class QueueStatsCommand(BaseCommand):
             prev_day = day_objs[day_objs.index(day) - 1]
             jobs_sched = self.jobs_scheduled_between(prev_day, day).count()
             jobs_done = self.jobs_completed_between(prev_day, day).count()
+            percent = float(jobs_done) / float(jobs_sched) * 100
             job_counts[day] = OrderedDict(scheduled=jobs_sched,
-                                          completed=jobs_done)
-            print "{day}: {sched: >4} scheduled, {done: >4} completed".format(
+                                          completed=jobs_done,
+                                          percent=percent,
+                                          )
+            print "{day}: {sched: >4} scheduled, {done: >4} completed ({percent:.0f}%)".format(
                 day=day,
                 sched=jobs_sched,
                 done=jobs_done,
+                percent=percent,
             )
 
     def jobs_scheduled_between(self, day1, day2):


### PR DESCRIPTION
Sample output, before and after:

```
(virtualenv)14:35:19 zack@zwork.local paddles master ? pecan queue_stats prod.py 7
No handlers could be found for logger "sqlalchemy.engine.base.Engine"
2015-01-29: 2013 scheduled, 1767 completed
2015-01-30: 1934 scheduled, 1843 completed
2015-01-31: 1331 scheduled, 1149 completed
2015-02-01: 1605 scheduled, 1448 completed
2015-02-02:  574 scheduled,  548 completed
2015-02-03: 1493 scheduled, 1368 completed
2015-02-04: 2553 scheduled, 1072 completed
(virtualenv)14:35:25 zack@zwork.local paddles master ? git checkout wip-queue-stats
Switched to branch 'wip-queue-stats'
(virtualenv)14:35:34 zack@zwork.local paddles wip-queue-stats ? pecan queue_stats prod.py 7
No handlers could be found for logger "sqlalchemy.engine.base.Engine"
2015-01-29: 2013 scheduled, 1767 completed (88%)
2015-01-30: 1934 scheduled, 1843 completed (95%)
2015-01-31: 1331 scheduled, 1149 completed (86%)
2015-02-01: 1605 scheduled, 1448 completed (90%)
2015-02-02:  574 scheduled,  548 completed (95%)
2015-02-03: 1493 scheduled, 1368 completed (92%)
2015-02-04: 2553 scheduled, 1072 completed (42%)
```