### PR TITLE
add is_container field

### DIFF
--- a/paddles/models/nodes.py
+++ b/paddles/models/nodes.py
@@ -25,6 +25,7 @@ class Node(Base):
     machine_type = Column(String(32), index=True)
     arch = Column(String(16))
     is_vm = Column(Boolean(), nullable=False, default=False)
+    is_container = Column(Boolean(), nullable=False, default=False)
 
     os_type = Column(String(32))
     os_version = Column(String(16), index=True)
@@ -48,6 +49,7 @@ class Node(Base):
         'os_type',
         'os_version',
         'is_vm',
+        'is_container',
         'locked',
         'locked_by',
         'locked_since',
@@ -190,6 +192,7 @@ class Node(Base):
             up=self.up,
             machine_type=self.machine_type,
             is_vm=self.is_vm,
+            is_container=self.is_container,
             vm_host=self.vm_host,
             os_type=self.os_type,
             os_version=self.os_version,


### PR DESCRIPTION
Containers (lxc, docker) require different code paths than virtual
machines and bare metal to take advantage of the fact that they may be
accessed via enter/exec and without requiring a ssh connection.

Signed-off-by: Loic Dachary <ldachary@redhat.com>