### PR TITLE
Remove lock-recycling misfeature

### DIFF
--- a/paddles/models/nodes.py
+++ b/paddles/models/nodes.py
@@ -149,21 +149,6 @@ class Node(Base):
             query = query.filter(Node.arch == arch)
         query = query.filter(Node.up.is_(True))
 
-        # First, try to recycle a user's already-locked nodes if description
-        # matches. In this case we don't care if the nodes are locked or not.
-        if description is not None:
-            recycle_q = query.filter(Node.locked_by == locked_by)
-            recycle_q = recycle_q.filter(Node.description == description)
-            recycle_q = recycle_q.limit(count)
-            nodes = recycle_q.all()
-            nodes_avail = len(nodes)
-            if nodes_avail == count:
-                log.info("Re-using {count} locks for {locked_by}".format(
-                    count=count, locked_by=locked_by))
-                for node in nodes:
-                    node.update(update_dict)
-                return nodes
-
         # Find unlocked nodes
         query = query.filter(Node.locked.is_(False))
         query = query.limit(count)

--- a/paddles/tests/controllers/test_nodes.py
+++ b/paddles/tests/controllers/test_nodes.py
@@ -233,9 +233,10 @@ class TestNodesController(TestApp):
         response = self.app.post_json(
             '/nodes/lock_many/',
             dict(count=count, machine_type='pet', description=desc,
-                 locked_by=locked_by)
+                 locked_by=locked_by),
+            expect_errors=True,
         )
-        assert len(response.json) == count
+        assert 'only 0' in response.json['message']
 
     def test_unlock_many_simple(self):
         mtype = 'ulmtest'


### PR DESCRIPTION
It was always a bad idea on multiple levels, but most importantly, it
can really confuse teuthology when it tries to lock and provision
downburst VMs.

http://tracker.ceph.com/issues/11808

Signed-off-by: Zack Cerza <zack@redhat.com>