### PR TITLE
remove unneeded models.init_model in commands/populate.py

### DIFF
--- a/paddles/commands/populate.py
+++ b/paddles/commands/populate.py
@@ -17,7 +17,6 @@ class PopulateCommand(BaseCommand):
         super(PopulateCommand, self).run(args)
         out("LOADING ENVIRONMENT")
         self.load_app()
-        models.init_model()
         out("BUILDING SCHEMA")
         try:
             out("STARTING A TRANSACTION...")


### PR DESCRIPTION
That line triggers the bug: http://tracker.ceph.com/issues/13595

In earlier versions of pecan the models.init_model() was needed, but in
later versions it is not.

In looking at the differences between chacra's populate command and paddle's I noticed this commit:

https://github.com/ceph/chacra/commit/cd8ab6c108fc176f0a4872ea11394adc20a28a67

Unfortunately there is not much context on that commit, but removing that line here in paddles fixes the populate command.