### PR TITLE
Parametrize expiration intervals

### DIFF
--- a/paddles/commands/expire_jobs.py
+++ b/paddles/commands/expire_jobs.py
@@ -9,12 +9,34 @@ from datetime import datetime, timedelta
 class ExpireJobsCommand(BaseCommand):
     """
     Mark stale jobs as 'dead'
+
+    A stale job, in this context, is a 'running' job that has not been updated
+    within a certain amount of time (usually a short interval like 30m) or a
+    'queued' job that has not been updated in a different amount of time
+    (usually a longer interval like 14d)
     """
-    running_delta = timedelta(seconds=60*60*0.5)
-    queued_delta = timedelta(days=14)
+
+    arguments = BaseCommand.arguments + (
+        dict(
+            name=["-r", "--running"],
+            help="How recently-updated (in minutes) a running job should be" +
+                 " to not be marked 'dead' (default: 30)",
+            default=30,
+        ),
+        dict(
+            name=["-q", "--queued"],
+            help="How recently-updated (in days) a queued job should be" +
+                 " to not be marked 'dead' (default: 14)",
+            default=14,
+        ),
+    )
 
     def run(self, args):
         super(ExpireJobsCommand, self).run(args)
+        self.running_minutes = int(args.running)
+        self.running_delta = timedelta(minutes=self.running_minutes)
+        self.queued_days = int(args.queued)
+        self.queued_delta = timedelta(days=self.queued_days)
         self.load_app()
         models.start()
         self.expire_running()


### PR DESCRIPTION
Instead of hardcoding the 30m for running jobs and 14d for queued jobs,
make them arguments that can be passed on the command line.

Signed-off-by: Zack Cerza <zack@redhat.com>