### PR TITLE
models: jobs stores ceph/ceph-qa-suite branch and sha1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,9 @@ database are:
 * tasks
 * teuthology_branch
 * verbose
+* branch
+* sha1
+* suite_sha1
 
 For initial creation of a ``job`` associated to its ``run`` a ``job_id`` key is
 **required**. It is the only key in the JSON body that *must* exist, otherwise

--- a/alembic/versions/4b86caad387e_add_ceph_and_ceph_qa_suite_fields.py
+++ b/alembic/versions/4b86caad387e_add_ceph_and_ceph_qa_suite_fields.py
@@ -1,0 +1,28 @@
+"""add ceph and ceph-qa-suite fields
+
+Revision ID: 4b86caad387e
+Revises: 2d1e995efc52
+Create Date: 2016-03-03 16:56:24.681108
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4b86caad387e'
+down_revision = '2d1e995efc52'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('jobs', sa.Column('sha1', sa.String(length=40),
+                                    nullable=True))
+    op.add_column('jobs', sa.Column('branch', sa.String(length=64),
+                                    nullable=True))
+    op.add_column('jobs', sa.Column('suite_sha1', sa.String(length=40),
+                                    nullable=True))
+
+def downgrade():
+    op.drop_column('jobs', 'sha1')
+    op.drop_column('jobs', 'branch')
+    op.drop_column('jobs', 'suite_sha1')

--- a/paddles/models/jobs.py
+++ b/paddles/models/jobs.py
@@ -50,7 +50,10 @@ class Job(Base):
     roles = deferred(Column(JSONType()))
     sentry_event = Column(String(128))
     success = Column(Boolean(), index=True)
+    branch = Column(String(64), index=True)
+    sha1 = Column(String(40), index=True)
     suite_branch = Column(String(64), index=True)
+    suite_sha1 = Column(String(40), index=True)
     targets = deferred(Column(JSONType()))
     target_nodes = relationship("Node", secondary=job_nodes_table,
                                 backref=backref('jobs'), lazy='dynamic')
@@ -82,7 +85,10 @@ class Job(Base):
         "sentry_event",
         "status",
         "success",
+        "branch",
+        "sha1",
         "suite_branch",
+        "suite_sha1",
         "targets",
         "tasks",
         "teuthology_branch",


### PR DESCRIPTION
The three new fields (sha1, branch and suite_sha1) are indexed. They are
already present in the json job description that teuthology/report.py
sends to paddle, there does not need to be a modification teuthology
side.

Signed-off-by: Loic Dachary <loic@dachary.org>