### PR TITLE
Submit pass/fail/dead job counts to statsd

### DIFF
--- a/config.py.in
+++ b/config.py.in
@@ -14,6 +14,11 @@ server = {
     'host': '127.0.0.1'
 }
 
+statsd = {
+    'host': 'example.com',
+    'prefix': 'ceph.test.teuthology.your_lab',
+}
+
 # These values will be specific to your site
 address = 'http://paddles.front.sepia.ceph.com'
 job_log_href_templ = 'http://qa-proxy.ceph.com/teuthology/{run_name}/{job_id}/teuthology.log'  # noqa

--- a/paddles/stats.py
+++ b/paddles/stats.py
@@ -1,0 +1,27 @@
+import logging
+import statsd
+
+from pecan import conf
+
+log = logging.getLogger(__name__)
+
+
+def get_client():
+    try:
+        host = conf.statsd.host
+        port = conf.statsd.get("port", statsd.Connection.default_port)
+        prefix = conf.statsd.prefix
+        statsd.Connection.set_defaults(
+            host=host,
+            port=port,
+        )
+    except AttributeError as exc:
+        log.info(
+            "Could not find statsd configuration; disabling statsd. "
+            "Error message was: %s" % exc.message
+        )
+        prefix = None
+        statsd.Connection.set_defaults(
+            disabled=True,
+        )
+    return statsd.Client(prefix)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ WebTest==2.0.18
 wsgiref==0.1.2
 gunicorn==19.3.0
 python-statsd==2.0.0
+mock==2.0.0
+pytest==3.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ tzlocal==1.2
 WebTest==2.0.18
 wsgiref==0.1.2
 gunicorn==19.3.0
+python-statsd==2.0.0


### PR DESCRIPTION
statsd is optional and disabled by default. This code is already running on paddles.front.sepia.ceph.com