### PR TITLE
bump gunicorn to 19.5.0 to avoid  CWE-113

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ SQLAlchemy==1.0.8
 tzlocal==1.2
 WebTest==2.0.18
 wsgiref==0.1.2
-gunicorn==19.3.0
+gunicorn==19.5.0
 python-statsd==2.0.0
 mock==2.0.0
 pytest==3.0.4


### PR DESCRIPTION
Fixes: https://nvd.nist.gov/vuln/detail/CVE-2018-1000164

Signed-off-by: Alfredo Deza <adeza@redhat.com>