### PR TITLE
ci: Fix travis syntax error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-
 services:
   - docker
 
@@ -10,5 +9,5 @@ before_install:
   - docker ps -a
 script:
   - curl http://localhost:80
-  - curl -d '{ "name": "testrun" }' -H 'Content-Type: application/json' http://localhost:80/runs/
+  - "curl -d '{ \"name\": \"testrun\" }' -H 'Content-Type: application/json' http://localhost:80/runs/"
   - curl http://localhost:80/runs/


### PR DESCRIPTION
Commit ea5d3c245e58 introduced TravisCI but the yaml configuration was
wrong. Fix that now.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>