### PR TITLE
Add GitHub Actions definition for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: CI on python${{ matrix.python }} via ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python: [3.6, 3.9]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install tox
+        run: pip install tox
+      - name: Run flake8
+        run: tox -e flake8
+      - name: Run unit tests
+        run: tox -e py3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic==0.8.2
 Mako==1.0.2
 mccabe==0.3.1
 pecan==1.3.3
-psycopg2==2.7.7
+psycopg2-binary==2.8.6
 pytz==2015.6
 requests==2.20.0
 simplegeneric==0.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ WebTest==2.0.18
 gunicorn==20.0.4
 python-statsd==2.0.0
 mock==2.0.0
-pytest==3.0.4
+pytest==6.2.4

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,8 @@ envlist = py3, flake8
 [testenv:py3]
 basepython=python3
 sitepackages=True
+whitelist_externals=
+  py.test
 deps=
   -r{toxinidir}/requirements.txt
 


### PR DESCRIPTION
This could replace our Jenkins tests, while also allowing us to trivially test multiple python versions.