### PR TITLE
Update psycopg2 to a version with py3 binaries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic==0.8.2
 Mako==1.0.2
 mccabe==0.3.1
 pecan==1.3.3
-psycopg2==2.7.7
+psycopg2==2.9.1
 pytz==2015.6
 requests==2.20.0
 simplegeneric==0.8.1


### PR DESCRIPTION
This is primarily to avoid build failures on MacOS, but could help on
Linux as well.

Signed-off-by: Zack Cerza <zack@redhat.com>