### PR TITLE
Replace psycopg2 with psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ alembic==0.8.2
 Mako==1.0.2
 mccabe==0.3.1
 pecan==1.3.3
-psycopg2==2.7.7
+psycopg2-binary==2.8.6
 pytz==2015.6
 requests==2.20.0
 simplegeneric==0.8.1


### PR DESCRIPTION
On some platforms, compiling psycopg2 isn't feasible.

Signed-off-by: Zack Cerza <zack@redhat.com>