### PR TITLE
Dockerfile: Switch to UBI8 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM ubuntu:18.04
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install \
-  -y --no-install-recommends \
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+RUN microdnf update -y && \
+  microdnf install -y \
 	curl \
 	lsof \
 	python3 \
-	python3-alembic \
-	python3-gunicorn \
 	python3-pip \
 	python3-setuptools \
 	python3-wheel \


### PR DESCRIPTION
This is more about moving away from Docker Hub than anything else,
because its rate limiting makes automated image building difficult.

At first I tried Fedora images, but Quay's security scanner does not
support them. I would have used Alpine, but their official images are
also only at Docker Hub. Red Hat's ubi8-minimal image should work.