### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ RUN microdnf update -y && \
 # Install dependencies:
 COPY requirements.txt .
 ADD . /paddles
-RUN pip3 install -r requirements.txt
-RUN pip3 install /paddles/.
+RUN pip3 install --no-cache-dir -r requirements.txt
+RUN pip3 install --no-cache-dir /paddles/.
 
 # Run the application:
 COPY config.py.in /paddles/config.py


### PR DESCRIPTION
using --no-cache-dir flag in pip install, make sure downloaded packages
by pip don't cache on the system. This is a best practice that makes sure
to fetch from repo instead of using local cached one. Further, in the case
of Docker Containers, by restricting caching, we can reduce image size.
In terms of stats, it depends upon the number of python packages
multiplied by their respective size. e.g for heavy packages with a lot
of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>