### PR TITLE
gunicorn_config.py: Don't log to files by default

### DIFF
--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,9 +1,9 @@
-import os
+# import os
 import multiprocessing
 
 workers = multiprocessing.cpu_count()
 max_requests = 10000
 timeout = 60
 # loglevel = 'debug'
-accesslog = os.path.expanduser("~/paddles.access.log")
+# accesslog = os.path.expanduser("~/paddles.access.log")
 # errorlog = os.path.expanduser("~/paddles.error.log")


### PR DESCRIPTION
This fixes a startup failure with podman