### PR TITLE
controllers/nodes: add missing records for return objects

### DIFF
--- a/paddles/controllers/nodes.py
+++ b/paddles/controllers/nodes.py
@@ -314,6 +314,8 @@ class NodeController(object):
             name=node_obj.name,
             locked=node_obj.locked,
             locked_by=node_obj.locked_by,
+            machine_type=node_obj.machine_type,
+            is_vm=node_obj.is_vm,
         )
 
     @expose('json')


### PR DESCRIPTION
On teuthology side at least for vms the lock/unlock mechanism still needs some records in return object like machine_type and is_vm:

https://github.com/ceph/teuthology/blob/main/teuthology/lock/cli.py#L168
https://github.com/ceph/teuthology/blob/main/teuthology/lock/cli.py#L174

Fixes: fb1c596bd68a559bb504a80dce39966cc6578c45