### PR TITLE
controllers/jobs: Add JobsListController

### DIFF
--- a/paddles/controllers/root.py
+++ b/paddles/controllers/root.py
@@ -1,6 +1,7 @@
 from pecan import expose
 
 from paddles.controllers.runs import RunsController
+from paddles.controllers.jobs import JobsListController
 from paddles.controllers.nodes import NodesController
 from paddles.controllers.errors import ErrorsController
 from paddles.controllers.queue import QueuesController
@@ -19,3 +20,4 @@ class RootController(object):
     errors = ErrorsController()
     nodes = NodesController()
     queue = QueuesController()
+    jobs = JobsListController()


### PR DESCRIPTION
This adds an endpoint to list jobs at new `/job` endpoint. By default, it returns latest posted jobs. We can add filter for description and status. 

Example:
`/jobs/?description=nvmeof/basic/{base/install%20centos_latest%20clusters/4-gateways-2-initiator%20conf/{disable-pool-app}%20workloads/nvmeof_scalability}&count=10&page=1`