### PR TITLE
controllers/runs: stop embedding full job objects in run response

### DIFF
--- a/paddles/controllers/runs.py
+++ b/paddles/controllers/runs.py
@@ -67,9 +67,7 @@ class RunController(object):
     def index(self):
         if not self.run:
             abort(404)
-        json_run = self.run.__json__()
-        json_run['jobs'] = self.run.get_jobs()
-        return json_run
+        return self.run.__json__()
 
     @index.when(method='DELETE', template='json')
     def index_delete(self):


### PR DESCRIPTION
`GET /runs/<name>/` was calling `self.run.get_jobs()` which loads every job row in full — including large text/JSON columns like `overrides`, `tasks`, `roles`, and `targets` — and serializes them all into the response. For runs with hundreds of jobs this produces ~1.6MB responses that take 8+ seconds to serialize in Python, despite the underlying DB query completing in ~2ms.

Job data is already available via `GET /runs/<name>/jobs/` which supports `?fields=` for callers to request only what they need. There is no reason for the run endpoint to duplicate this.

This change removes the `get_jobs()` call from `RunController.index()` so the run endpoint returns only run-level metadata. Callers that need job data should use `/runs/<name>/jobs/` directly, optionally with `?fields=` to limit the response to needed fields.

A companion change to pulpito updates `RunController.get_run()` to fetch jobs separately via `/runs/<name>/jobs/?fields=<needed fields>` rather than relying on the embedded jobs in the run response. Performance impact measured on a 300-job run:

Before: 8s, 1.6MB
After: <50ms, ~5KB